### PR TITLE
Add ability pass your own AMQPMessage instance

### DIFF
--- a/components/Amqp.php
+++ b/components/Amqp.php
@@ -191,6 +191,10 @@ class Amqp extends Component
      */
     public function prepareMessage($message, $properties = null)
     {
+        if ($message instanceof AMQPMessage) {
+            return $message;
+        }
+
         if (empty($message)) {
             throw new Exception('AMQP message can not be empty');
         }


### PR DESCRIPTION
Currently there is no possibility to set your own properties of a message. This way you send a message with your own set properties like that it's persistent.

This way seems a better approach then adding another argument to send()/ask().